### PR TITLE
Modify truncate_tables to ignore the spatial_ref_sys table

### DIFF
--- a/lib/active_record/connection_adapters/postgis/database_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/database_statements.rb
@@ -1,0 +1,12 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module PostGIS
+      module DatabaseStatements
+        def truncate_tables(*table_names)
+          table_names -= ["spatial_ref_sys"]
+          super(*table_names)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/postgis/version.rb
+++ b/lib/active_record/connection_adapters/postgis/version.rb
@@ -1,0 +1,7 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module PostGIS
+      VERSION = '7.0.0.2'
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -1,7 +1,9 @@
 require 'active_record/connection_adapters/postgresql_adapter'
+require 'active_record/connection_adapters/postgis/version'
 require 'active_record/connection_adapters/postgis/oid/geometry'
 require 'active_record/connection_adapters/postgis/schema_definitions'
 require 'active_record/connection_adapters/postgis/schema_statements'
+require 'active_record/connection_adapters/postgis/database_statements'
 
 ActiveRecord::SchemaDumper.ignore_tables |= %w[geometry_columns spatial_ref_sys layer topology]
 module ActiveRecord
@@ -42,6 +44,7 @@ module ActiveRecord
       })
 
       include PostGIS::SchemaStatements
+      include PostGIS::DatabaseStatements
 
       class << self
         def initialize_type_map(m)

--- a/postgis_adapter.gemspec
+++ b/postgis_adapter.gemspec
@@ -1,9 +1,8 @@
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require_relative "lib/active_record/connection_adapters/postgis/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "postgis_adapter"
-  spec.version       = '7.0.0.1'
+  spec.version       = ActiveRecord::ConnectionAdapters::PostGIS::VERSION
   spec.authors       = ["James Bracy"]
   spec.email         = ["waratuman@gmail.com"]
   spec.description   = %q{ActiveRecord PostGIS Database Adapter}


### PR DESCRIPTION
During parallelized tests, ActiveRecord uses the truncate_tables method which truncates all of the tables in the database except for ar_internal_metadata and schema_migrations. This PR also excludes the spatial_ref_sys table from being truncated.

This is occurring on ActiveRecord 6+