### PR TITLE
Fix schema dump of geometry columns on Rails 8.1

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -12,14 +12,22 @@ module ActiveRecord
     class PostGISAdapter < PostgreSQLAdapter
       ADAPTER_NAME = 'PostGIS'.freeze
 
-      NATIVE_DATABASE_TYPES = PostgreSQLAdapter::NATIVE_DATABASE_TYPES.merge({
+      POSTGIS_NATIVE_DATABASE_TYPES = {
         geometry: { name: "geometry" },
-      })
+      }.freeze
+
+      NATIVE_DATABASE_TYPES = PostgreSQLAdapter::NATIVE_DATABASE_TYPES.merge(POSTGIS_NATIVE_DATABASE_TYPES)
 
       include PostGIS::SchemaStatements
       include PostGIS::DatabaseStatements
 
       class << self
+        # PostgreSQLAdapter.native_database_types resolves NATIVE_DATABASE_TYPES
+        # lexically, so shadowing the constant in this subclass has no effect.
+        def native_database_types # :nodoc:
+          @native_database_types ||= super.merge(POSTGIS_NATIVE_DATABASE_TYPES)
+        end
+
         def initialize_type_map(m)
           register_class_with_limit m, "geometry", PostGIS::OID::Geometry
           super
@@ -27,7 +35,7 @@ module ActiveRecord
 
         def extract_limit(sql_type)
           if sql_type =~ /geometry\(([a-zA-Z]*),(\d+)\)/i
-            { :type => $1, :srid => $2 }
+            { :type => $1, :srid => $2.to_i }
           else
             super
           end

--- a/test/cases/adapters/postgis/schema_dumper_test.rb
+++ b/test/cases/adapters/postgis/schema_dumper_test.rb
@@ -1,0 +1,41 @@
+require 'cases/helper'
+require 'stringio'
+
+class PostGISSchemaDumper < ActiveSupport::TestCase
+
+  def test_geometry_is_a_native_database_type
+    assert_includes ActiveRecord::ConnectionAdapters::PostGISAdapter.native_database_types, :geometry
+    assert connection.valid_type?(:geometry)
+  end
+
+  def test_native_database_types_keeps_the_postgresql_types
+    assert_equal connection.class.superclass.native_database_types[:datetime],
+      ActiveRecord::ConnectionAdapters::PostGISAdapter.native_database_types[:datetime]
+  end
+
+  def test_dumps_tables_with_geometry_columns
+    dump = dump_schema
+
+    refute_match(/Could not dump table/, dump)
+    assert_match(/t\.geometry\s+"point",\s+limit: \{.*type: "Point".*srid: 4326.*\}/, dump)
+  end
+
+  def test_dumps_srid_as_an_integer
+    limit = connection.columns(:geos).find { |c| c.name == "point" }.limit
+
+    assert_equal({ type: "Point", srid: 4326 }, limit)
+  end
+
+  private
+
+  def connection
+    ActiveRecord::Base.lease_connection
+  end
+
+  def dump_schema
+    io = StringIO.new
+    ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, io)
+    io.string
+  end
+
+end

--- a/test/cases/adapters/postgis/schema_dumper_test.rb
+++ b/test/cases/adapters/postgis/schema_dumper_test.rb
@@ -17,7 +17,8 @@ class PostGISSchemaDumper < ActiveSupport::TestCase
     dump = dump_schema
 
     refute_match(/Could not dump table/, dump)
-    assert_match(/t\.geometry\s+"point",\s+limit: \{.*type: "Point".*srid: 4326.*\}/, dump)
+    # Ruby < 3.4 inspects hashes as {:type=>"Point"}, 3.4+ as {type: "Point"}.
+    assert_match(/t\.geometry\s+"point",\s+limit: \{[^}]*"Point"[^}]*4326[^}]*\}/, dump)
   end
 
   def test_dumps_srid_as_an_integer


### PR DESCRIPTION
Fixes #8.

`PostgreSQLAdapter.native_database_types` resolves `NATIVE_DATABASE_TYPES` lexically, so the subclass constant shadow in `PostGISAdapter` never took effect — `valid_type?(:geometry)` returned `false` and `SchemaDumper` silently replaced every spatial table in `db/schema.rb` with a "Could not dump table" comment. This overrides the class method instead, merging into `super` so Rails' documented registration point (mutating `PostgreSQLAdapter::NATIVE_DATABASE_TYPES` in an initializer) still works and the parent's `datetime` handling is preserved.

`extract_limit` now returns `srid` as an `Integer` so the dumped hash reads `limit: {type: "Point", srid: 4326}` instead of a quoted string. Adds `test/cases/adapters/postgis/schema_dumper_test.rb`, which fails on the old code and passes here; the dump was also verified to round-trip through `schema:load` with identical `sql_type` and `limit` on every column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)